### PR TITLE
Check group is a microsite.

### DIFF
--- a/localgov_microsites_base.theme
+++ b/localgov_microsites_base.theme
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\domain_group\DomainGroupHelper;
+use Drupal\localgov_microsites_group\Entity\MicrositeGroupInterface;
 
 /**
  * @file Theme function for the LocalGov Microsites Base theme.
@@ -21,7 +22,7 @@ function localgov_microsites_base_preprocess_html(&$variables) {
     $group = \Drupal::request()->attributes->get('group');
   }
 
-  if (!empty($group)) {
+  if ($group instanceof MicrositeGroupInterface) {
 
     // Styleguide primary colour
     if (!is_null($group->get('lgms_primary_colour')[0])) {
@@ -154,8 +155,7 @@ function localgov_microsites_base_preprocess_page(&$variables) {
     $group = \Drupal::request()->attributes->get('group');
   }
 
-  if (!empty($group)) {
-    $group = \Drupal::entityTypeManager()->getStorage('group')->load($parent_group_id);
+  if ($group instanceof MicrositeGroupInterface) {
     $variables['microsites']['group']['entity'] = $group;
     $variables['microsites']['group']['id'] = $parent_group_id;
     if (!empty($group->get('lgms_footer_width')->getValue())) {


### PR DESCRIPTION
Means site doesn't break when accessing fields that aren't on some other group type.

At the moment the preprocess accesses fields without checking they exist, so fatal errors if a field is not there. It should maybe check the field is on the entity - should someone change any of the fields - but this is quicker - it just checks if it's a microsite type.