### PR TITLE
only show pre-header if search block is switched on

### DIFF
--- a/localgov_microsites_base.theme
+++ b/localgov_microsites_base.theme
@@ -455,7 +455,7 @@ function localgov_microsites_base_preprocess_node(&$variables) {
 
     $node_id = $variables['node']->nid[0]->getValue()['value'];
     $front_page = \Drupal::config('domain.config.group_' . $parent_group_id . '.system.site')->get('page.front');
-    strstr($front_page, 'node') ? $front_page_id = explode("/node/", $front_page )[1] : '';
+    strstr($front_page, 'node') ? $front_page_id = explode("/node/", $front_page)[1] : '';
 
     if ($front_page_id && $front_page_id === $node_id && $variables['view_mode'] === 'full') {
       if (isset($group->get('lgms_hide_title')[0])) {

--- a/templates/layout/includes/microsites-header.html.twig
+++ b/templates/layout/includes/microsites-header.html.twig
@@ -23,26 +23,29 @@
 %}
 
 {# Begin pre-header #}
-{% if microsites.pre_header.width.content_centered %}
-  <div class="lgd-container">
-{% endif %}
-<div class="microsite-header__pre-header">
+{% if has_search and microsites.pre_header.items.lgms_display_sitewide_search.0['#markup'] == 'On' %}
 
-  {% if microsites.pre_header.width.full_width_content_contained %}
-    <div class="lgd-container padding-horizontal">
+  {% if microsites.pre_header.width.content_centered %}
+    <div class="lgd-container">
   {% endif %}
-  {% if has_search and microsites.pre_header.items.lgms_display_sitewide_search.0['#markup'] == 'On' %}
-    <div class="microsite-header__search">
-      {{ page.search }}
-    </div>
-  {% endif %}
-  {% if microsites.pre_header.width.full_width_content_contained %}
-    </div>
-  {% endif %}
-</div>
+  <div class="microsite-header__pre-header">
 
-{% if microsites.pre_header.width.content_centered %}
+    {% if microsites.pre_header.width.full_width_content_contained %}
+      <div class="lgd-container padding-horizontal">
+    {% endif %}
+    {% if has_search and microsites.pre_header.items.lgms_display_sitewide_search.0['#markup'] == 'On' %}
+      <div class="microsite-header__search">
+        {{ page.search }}
+      </div>
+    {% endif %}
+    {% if microsites.pre_header.width.full_width_content_contained %}
+      </div>
+    {% endif %}
   </div>
+
+  {% if microsites.pre_header.width.content_centered %}
+    </div>
+  {% endif %}
 {% endif %}
 {# End pre-header #}
 


### PR DESCRIPTION
Closes #148 

I don't particularly like this approach as it presumes we will only every have a search block in that region (though, we do have it called `search` rather than `pre_header` for some reason).