### PR TITLE
Don't show breadcrumbs on homepages by default. #207

### DIFF
--- a/config/install/block.block.localgov_microsites_base_breadcrumbs.yml
+++ b/config/install/block.block.localgov_microsites_base_breadcrumbs.yml
@@ -16,4 +16,8 @@ settings:
   label: Breadcrumbs
   label_display: '0'
   provider: system
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: true
+    pages: '<front>'

--- a/localgov_microsites_base.post_update.php
+++ b/localgov_microsites_base.post_update.php
@@ -24,6 +24,6 @@ function localgov_microsites_base_post_update_frontpage_breadcrumb() {
   }
   else {
     // Changed from default. Just set a note.
-    return \t('Breadcrumb block has been update since install. If you would like it not to be shown on front pages change the block visibility to exclude <front>.');
+    return \t('Breadcrumb block has been updated since install. If you would like it not to be shown on front pages change the block visibility to exclude <front>.');
   }
 }

--- a/localgov_microsites_base.post_update.php
+++ b/localgov_microsites_base.post_update.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for LocalGov Microsites Base theme.
+ */
+
+use Drupal\block\Entity\Block;
+
+/**
+ * Remove breadcrumbs from the front page.
+ */
+function localgov_microsites_base_post_update_frontpage_breadcrumb() {
+  $breadcrumb_block = Block::load('localgov_microsites_base_breadcrumbs');
+  $visibility = $breadcrumb_block->getVisibility();
+  if (empty($visibility)) {
+    $breadcrumb_block->setVisibilityConfig('request_path', [
+      'id' => 'request_path',
+      'negate' => true,
+      'pages' => '<front>',
+    ]);
+    $breadcrumb_block->save();
+    return \t('Breadcrumb block removed from front pages.');
+  }
+  else {
+    // Changed from default. Just set a note.
+    return \t('Breadcrumb block has been update since install. If you would like it not to be shown on front pages change the block visibility to exclude <front>.');
+  }
+}


### PR DESCRIPTION
An alternative simple version for hiding breadcrumbs from all frontpages by default.

Existing sites will need to have the configuration updated.