### PR TITLE
Bug/109 equal heights resize

### DIFF
--- a/js/equal-heights-blocks.js
+++ b/js/equal-heights-blocks.js
@@ -28,6 +28,11 @@
               block.style.height = `${tallestBlock}px`;
             });
           }
+
+          // We need a setTimeout here because the images take just
+          // a tiny bit to load, which causes the layout to be set
+          // before they are in place, then they get positioned
+          // wrong on first load.
           setTimeout(() => {
             removeExistingHeights();
             handleGetHeights();

--- a/js/equal-heights-blocks.js
+++ b/js/equal-heights-blocks.js
@@ -50,7 +50,6 @@
         layoutsWithTeaserBlocks.forEach(layout => {
           equaliseHeightsOfTheseBlocks(layoutsWithTeaserBlocks, '.featured-teaser');
         });
-        console.log('handle equalise was called');
       }
 
       handleEqualise();

--- a/js/equal-heights-blocks.js
+++ b/js/equal-heights-blocks.js
@@ -53,10 +53,8 @@
       }
 
       handleEqualise();
-
-      window.addEventListener('resize', function(event) {
-        handleEqualise();
-      }, true);
+      
+      window.addEventListener('resize', Drupal.debounce(handleEqualise, 250, true));
     }
   };
 }(Drupal));

--- a/js/equal-heights-blocks.js
+++ b/js/equal-heights-blocks.js
@@ -13,6 +13,12 @@
           const blocksToEqualiseHeights = item.querySelectorAll(typeOfBlock);
           const blockHeights = [];
 
+          function removeExistingHeights() {
+            blocksToEqualiseHeights.forEach(block => {
+              block.style.height = "";
+            });
+          }
+
           function handleGetHeights() {
             blocksToEqualiseHeights.forEach(block => {
               blockHeights.push(block.offsetHeight);
@@ -22,29 +28,31 @@
               block.style.height = `${tallestBlock}px`;
             });
           }
-
-          // We need a setTimeout here because the images take just
-          // a tiny bit to load, which causes the layout to be set
-          // before they are in place, then they get positioned
-          // wrong on first load.
           setTimeout(() => {
+            removeExistingHeights();
             handleGetHeights();
           }, 250);
         })
       }
 
-      layoutsWithCallOutBox.forEach(layout => {
-        equaliseHeightsOfTheseBlocks(layoutsWithCallOutBox, '.call-out-box');
-      });
+      function handleEqualise() {
+        layoutsWithCallOutBox.forEach(layout => {
+          equaliseHeightsOfTheseBlocks(layoutsWithCallOutBox, '.call-out-box');
+        });
+        layoutsWithIaBlocks.forEach(layout => {
+          equaliseHeightsOfTheseBlocks(layoutsWithIaBlocks, '.ia-block');
+        });
+        layoutsWithTeaserBlocks.forEach(layout => {
+          equaliseHeightsOfTheseBlocks(layoutsWithTeaserBlocks, '.featured-teaser');
+        });
+        console.log('handle equalise was called');
+      }
 
-      layoutsWithIaBlocks.forEach(layout => {
-        equaliseHeightsOfTheseBlocks(layoutsWithIaBlocks, '.ia-block');
-      });
+      handleEqualise();
 
-      layoutsWithTeaserBlocks.forEach(layout => {
-        equaliseHeightsOfTheseBlocks(layoutsWithTeaserBlocks, '.featured-teaser');
-      });
-
+      window.addEventListener('resize', function(event) {
+        handleEqualise();
+      }, true);
     }
   };
 }(Drupal));

--- a/localgov_microsites_base.libraries.yml
+++ b/localgov_microsites_base.libraries.yml
@@ -23,11 +23,6 @@ header:
     theme:
       css/components/header.css: {}
 
-cookies:
-  css:
-    theme:
-      css/components/cookies.css: {}
-
 equal-heights-blocks:
   js:
     js/equal-heights-blocks.js: {}

--- a/localgov_microsites_base.libraries.yml
+++ b/localgov_microsites_base.libraries.yml
@@ -23,11 +23,17 @@ header:
     theme:
       css/components/header.css: {}
 
+cookies:
+  css:
+    theme:
+      css/components/cookies.css: {}
+
 equal-heights-blocks:
   js:
     js/equal-heights-blocks.js: {}
   dependencies:
     - core/drupal
+    - core/drupal.debounce
 
 header-js:
   js:


### PR DESCRIPTION
I was going to create a new bug for this but believe this addresses an issue discussed here: https://github.com/localgovdrupal/localgov_microsites_base/issues/109

I was asked to look at an issue with text spilling out of 'featured-teaser' blocks when the page is resized. I traced it to the equal heights JS not calling the function on window resize.