### PR TITLE
Expand supprt for 4.x branch of localgov_microsites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
     "require": {
         "drupal/twig_tweak": "^3.2",
         "localgovdrupal/localgov_base": "^1.0.0",
-        "localgovdrupal/localgov_microsites_group": "dev-feature/group_sites"
+        "localgovdrupal/localgov_microsites_group": "^2.0.0@beta || ^3.0.0@alpha || ^4.0.0@alpha "
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
     "require": {
         "drupal/twig_tweak": "^3.2",
         "localgovdrupal/localgov_base": "^1.0.0",
-        "localgovdrupal/localgov_microsites_group": "^2.0.0@beta || ^3.0.0@alpha"
+        "localgovdrupal/localgov_microsites_group": "dev-feature/group_sites"
     }
 }

--- a/config/install/block.block.localgov_microsites_base_main_menu.yml
+++ b/config/install/block.block.localgov_microsites_base_main_menu.yml
@@ -5,7 +5,6 @@ dependencies:
     - group_content_menu.group_content_menu_type.lgms_main_menu
   module:
     - group_content_menu
-    - domain_group
   theme:
     - localgov_microsites_base
 id: localgov_microsites_base_main_menu

--- a/config/install/block.block.localgov_microsites_base_off_canvas_main_menu.yml
+++ b/config/install/block.block.localgov_microsites_base_off_canvas_main_menu.yml
@@ -5,7 +5,6 @@ dependencies:
     - group_content_menu.group_content_menu_type.lgms_main_menu
   module:
     - group_content_menu
-    - domain_group
   theme:
     - localgov_microsites_base
 id: localgov_microsites_base_off_canvas_main_menu

--- a/config/install/block.block.localgov_microsites_base_off_canvas_utility_menu.yml
+++ b/config/install/block.block.localgov_microsites_base_off_canvas_utility_menu.yml
@@ -5,7 +5,6 @@ dependencies:
     - group_content_menu.group_content_menu_type.lgms_utility_menu
   module:
     - group_content_menu
-    - domain_group
   theme:
     - localgov_microsites_base
 id: localgov_microsites_base_off_canvas_utility_menu

--- a/config/install/block.block.localgov_microsites_base_utility_menu.yml
+++ b/config/install/block.block.localgov_microsites_base_utility_menu.yml
@@ -5,7 +5,6 @@ dependencies:
     - group_content_menu.group_content_menu_type.lgms_utility_menu
   module:
     - group_content_menu
-    - domain_group
   theme:
     - localgov_microsites_base
 id: localgov_microsites_base_utility_menu


### PR DESCRIPTION
Hi @markconroy 

We're trying to get the 4.0.0-alpha1 of localgov_microsites released, so this should allow us to do so without creating another branch here.

I don't think removing the dependency on domain_group will break anything, but worth double checking.

Cheers,

Finn