### PR TITLE
2.0.2

### DIFF
--- a/templates/content/node--localgov-event--full.html.twig
+++ b/templates/content/node--localgov-event--full.html.twig
@@ -1,0 +1,137 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+
+{% set content_type = node.bundle %}
+
+{% if not localgov_base_remove_css %}
+  {{ attach_library('localgov_base/full') }}
+{% endif %}
+
+{{ attach_library('localgov_base/events') }}
+
+{%
+  set classes = [
+    content_type|clean_class,
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    content_type in restricted_width_content_types ? 'node--with-restricted-width',
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+
+<article{{ attributes.addClass(classes).removeAttribute('role') }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+
+  <div class="lgd-container padding-horizontal">
+
+    <div class="full__breadcrumbs">
+      {{ drupal_entity('block', 'localgov_microsites_base_breadcrumbs') }}
+    </div>
+
+    <div class="node__restricted-width-section">
+      {% set atc_title = node.title.value %}
+
+      {% if node.localgov_event_date.value %}
+        {% set atc_start_date = node.localgov_event_date.value %}
+      {% endif %}
+
+      {% if node.localgov_event_date.end_value %}
+        {% set atc_end_date = node.localgov_event_date.end_value %}
+      {% endif %}
+
+      {% if node.localgov_event_date.0.rrule %}
+        {% set atc_rrule = node.localgov_event_date.0.rrule %}
+      {% endif %}
+
+      {% if node.body.summary %}
+        {% set atc_details = node.body.summary %}
+      {% endif %}
+
+      {% set atc_location_variable = node.localgov_event_location.entity.postal_address.value.0 %}
+      {% if atc_location_variable %}
+        {% set atc_location = atc_location_variable.address_line1 ~ ', ' ~ atc_location_variable.locality ~ ', ' ~ atc_location_variable.postal_code %}
+      {% endif %}
+
+      <div{{ content_attributes.addClass(content_type|clean_class ~ '__content', 'node__content') }}>
+        {{ content.localgov_event_date }}
+        {% include "@localgov_base/_components/add-to-calendar.twig" %}
+        {{ content|without('localgov_event_date') }}
+      </div>
+
+    </div>
+  </div>
+</article>


### PR DESCRIPTION
This is a small release which just adds the events template to the base theme.

This is the same as the events template in LocalGov Base, except it also prints the breadcrumbs inside it (just like the other microsites templates).

If you already have a `node--localgov-event--full.html.twig` file in your custom theme, that will override this base theme, so you will see no extra changes.