### PR TITLE
A version bump for a 2.0.3 version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "drupal/twig_tweak": "^3.2",
-        "localgovdrupal/localgov_base": "^1.0.0",
+        "localgovdrupal/localgov_base": "^1.7.0",
         "localgovdrupal/localgov_microsites_group": "^4.0.0-alpha3"
     }
 }


### PR DESCRIPTION
Then the profile can depend on this at 2.0.3; and get 1.7.0; and have the module that needs to get enabled.

See https://github.com/localgovdrupal/localgov/pull/741 and the equivalent PR that will be coming for localgov_microsites and https://github.com/localgovdrupal/localgov_base/pull/569