### PR TITLE
adds visually hidden span for logo

### DIFF
--- a/templates/layout/includes/microsites-header.html.twig
+++ b/templates/layout/includes/microsites-header.html.twig
@@ -62,6 +62,7 @@
         <div class="microsite-header__logo">
           <a href="/">
             {{ microsites.header.items.lgms_main_logo }}
+            <span class="visually-hidden">{{ 'Home'|t }}</span>
           </a>
         </div>
       {% endif %}


### PR DESCRIPTION
Closes #281 

## What does this change?
Adds a visually-hidden span to announce to screenreaders that they logo in the header links to home.
