### PR TITLE
sets site name to align left if no menu items present

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -61,6 +61,26 @@
   }
 }
 
+/*
+  Let me try explain this one.
+  Our default `justify-content` is `space-between` with the menus having
+  a `margin-left: auto`, meaning they float to the right, while the rest of the
+  items stay at the left.
+
+  However, if we have no menu items, but WE DO have a name and slogan, we want
+  them to stay at the left, so we change the `justify-content` to `start`.
+
+  So, the CSS here says:
+    1. If there is a name/slogan div,
+    2. And there is no menu div,
+    3. Then change the `justify-content` to `start`.
+*/
+.microsite-header__main:has(.microsite-header__name-slogan):not(
+    :has(.microsite-header__menus)
+  ) {
+  justify-content: start;
+}
+
 .microsite-header__menu .menu--menu-level-0 {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #291 

## What does this change?

Does a bit of funky/crazy CSS `:has:not:has` dancing to figure out if the header items should use `justify-content: space-between` or `justify-content: start`. 

## How to test

1. Create a microsite
2. Add a menu
3. Enable 'Show site name'
4. Make sure all is fine
5. Delete the menu items
6. Make sure the site logo and site name remain on the left

