### PR TITLE
corrects path for submenu items if CSS agg is turned on

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -77,7 +77,7 @@ body {
   --menu-main-font-size: var(--font-size-h3);
   --menu-main-font-weight: var(--heading-font-weight);
   --minimum-clickable-icon-size: 44px; /* Setting default to 44px as per https://www.w3.org/WAI/WCAG21/Understanding/target-size.html */
-  --menu-sub-menu-icon: url(../../includes/icons/chevron-right.svg);
+  --menu-sub-menu-icon: url(/themes/contrib/localgov_microsites_base/includes/icons/chevron-right.svg);
   --menu-sub-menu-icon-size: 1.2rem;
   --menu-sub-menu-toggle-width: var(--minimum-clickable-icon-size);
   --menu-sub-menu-toggle-height: var(--minimum-clickable-icon-size);
@@ -93,7 +93,7 @@ body {
   --off-canvas-link-color: var(--header-link-color);
   --off-canvas-link-hover-color: var(--header-link-hover-color);
   --off-canvas-border-color: var(--color-white);
-  --off-canvas-menu-icon: url(../../includes/icons/menu.svg);
+  --off-canvas-menu-icon: url(/themes/contrib/localgov_microsites_base/includes/icons/menu.svg);
 
   /* Applying variables for Footer */
   --footer-background-color: var(--color-accent);

--- a/localgov_microsites_base.theme
+++ b/localgov_microsites_base.theme
@@ -371,7 +371,7 @@ function localgov_microsites_base_preprocess_html(&$variables) {
     // Main menu submenu icon.
     if (!is_null($group->get('lgms_submenu_icon')[0])) {
       $submenu_icon = $group->get('lgms_submenu_icon')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--menu-sub-menu-icon: url(../../includes/icons/' . $submenu_icon . '.svg) ;';
+      $variables['attributes']['style'][] = '--menu-sub-menu-icon: url(/themes/contrib/localgov_microsites_base/includes/icons/' . $submenu_icon . '.svg) ;';
     }
 
     // Main menu submenu icon rotation.
@@ -383,7 +383,7 @@ function localgov_microsites_base_preprocess_html(&$variables) {
     // Off canvas menu icon.
     if (!is_null($group->get('lgms_off_canvas_menu_icon')[0])) {
       $off_canvas_menu_icon = $group->get('lgms_off_canvas_menu_icon')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--off-canvas-menu-icon: url(../../includes/icons/' . $off_canvas_menu_icon . '.svg) ;';
+      $variables['attributes']['style'][] = '--off-canvas-menu-icon: url(/themes/contrib/localgov_microsites_base/includes/icons/' . $off_canvas_menu_icon . '.svg) ;';
     }
 
     // Off canvas background colour.


### PR DESCRIPTION
Closes #218 

## What does this change?

Our paths to icons are set via `../../includes...svg` which is fine when no aggregation is turned on. But once aggregation is turned on, the CSS files are now in `/sites/default/files/css...` so `../../includes...` will equate to `/sites/default/files` which will not have our `includes` directory in it.

## How to test

- Create a menu with some sub menu items
- Turn on CSS aggregation
- Check we do not have sub menu icons
- Check out this branch
- Clear the cache
- Check that we have sub menu icons
