### PR TITLE
Ensure margin does not push linked title out of banner

### DIFF
--- a/css/components/banner.css
+++ b/css/components/banner.css
@@ -16,9 +16,3 @@
   grid-column: 2;
 }
 
-.banner--primary .banner__link {
-  display: block;
-  max-width: var(--banner-content-width);
-  margin: calc(var(--banner-content-margin) * -1) auto
-    var(--banner-content-margin);
-}


### PR DESCRIPTION
## What does this change?

This fixes the issue raised in issue #298.

## How to test

Issue replication instructions are available in issue #298. 

To recreate the issue with this PR, simply add the code below on a microsite which is using a primary banner on a microsite which is using localgov microsite base as its theme:

```css
.banner--primary .banner__link {
  display: block;
  max-width: var(--banner-content-width);
  margin: calc(var(--banner-content-margin) * -1) auto
    var(--banner-content-margin);
}
```

## How can we measure success?

Users will be happier if they are experiencing the issue on their site and developers will be able to remove any patches they have created.

## Have we considered potential risks?

Given this is scoped to the microsite base theme, I don't see it affecting localgov base. It could potentially affect subthemes but I assume many will have rectified this issue.

## Images

### Before
![image](https://github.com/user-attachments/assets/d6fc9ed5-73ee-43d9-960e-f5b07db79ccc)

### After
![image](https://github.com/user-attachments/assets/5b553ecf-fa74-4e38-add0-96067997ae8b)


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [X] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)