### PR TITLE
Fix focus link colour for mobile menu

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -93,7 +93,8 @@ body {
   --off-canvas-background-color: var(--header-background-color);
   --off-canvas-text-color: var(--header-text-color);
   --off-canvas-link-color: var(--header-link-color);
-  --off-canvas-link-hover-color: var(--color-accent);
+  --off-canvas-link-focus-color: var(--color-accent);
+  --off-canvas-link-hover-color: var(--header-link-hover-color);
   --off-canvas-border-color: var(--color-white);
   --off-canvas-menu-icon: url(../../includes/icons/menu.svg);
 

--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -93,7 +93,7 @@ body {
   --off-canvas-background-color: var(--header-background-color);
   --off-canvas-text-color: var(--header-text-color);
   --off-canvas-link-color: var(--header-link-color);
-  --off-canvas-link-hover-color: var(--header-link-hover-color);
+  --off-canvas-link-hover-color: var(--color-accent);
   --off-canvas-border-color: var(--color-white);
   --off-canvas-menu-icon: url(../../includes/icons/menu.svg);
 

--- a/css/components/off-canvas.css
+++ b/css/components/off-canvas.css
@@ -41,7 +41,10 @@
   color: var(--off-canvas-link-color);
 }
 
-.off-canvas a:focus,
+.off-canvas a:focus {
+  color: var(--off-canvas-link-focus-color);
+}
+
 .off-canvas a:hover {
   color: var(--off-canvas-link-hover-color);
 }

--- a/css/components/off-canvas.css
+++ b/css/components/off-canvas.css
@@ -41,7 +41,8 @@
   color: var(--off-canvas-link-color);
 }
 
-.off-canvas a:focus {
+.off-canvas a:focus,
+.off-canvas a:focus:hover {
   color: var(--off-canvas-link-focus-color);
 }
 


### PR DESCRIPTION
Closes #306

Sets focus colour for mobile menu items to dark (on yellow) instead of white (on yellow).