### PR TITLE
Removed extra closing bracket

### DIFF
--- a/templates/layout/includes/microsites-footer.html.twig
+++ b/templates/layout/includes/microsites-footer.html.twig
@@ -33,7 +33,7 @@
 {{ attach_library('localgov_microsites_base/footer') }}
 
 {% if microsites.footer.items.lgms_footer_banner %}
-  <div {{ attributes.addClass(footer_banner_classes)}})>
+  <div {{ attributes.addClass(footer_banner_classes) }}>
     {{ microsites.footer.items.lgms_footer_banner }}
   </div>
 {% endif %}


### PR DESCRIPTION
Removed the closing bracket ")" in the footer_banner div

This caused the following HTML to be included on the page:

```
<div class="microsite-footer__banner lgd-container" )="">
...
</div>
```
