### PR TITLE
Move <div> inside "if content.group_page_bottom"

### DIFF
--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -124,10 +124,10 @@
     </div>
   {% endif %}
 
-  <div class="lgd-container padding-horizontal">
-    {% if content.group_page_bottom %}
+  {% if content.group_page_bottom %}
+    <div class="lgd-container padding-horizontal">
       {{ content.group_page_bottom }}
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 
 </article>


### PR DESCRIPTION
Moving `<div class="lgd-container padding-horizontal">` inside `{% if content.group_page_bottom %}` so that we don't get an empty `div` when `content.group_page_bottom` is empty

Without this change we get:
```
<div class="lgd-container padding-horizontal">
</div>
```
At the end of the `<article>`