### PR TITLE
only fire offcanvas click if off canvas is open

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -66,7 +66,6 @@
               !offCanvas.contains(e.target) &&
               offCanvas.getAttribute("data-expanded") === "true"
             ) {
-              console.log("click outside off-canvas");
               handleCloseOffCanvas();
             }
           });

--- a/js/header.js
+++ b/js/header.js
@@ -63,8 +63,10 @@
             if (
               offCanvasToggle &&
               !offCanvasToggle.contains(e.target) &&
-              !offCanvas.contains(e.target)
+              !offCanvas.contains(e.target) &&
+              offCanvas.getAttribute("data-expanded") === "true"
             ) {
+              console.log("click outside off-canvas");
               handleCloseOffCanvas();
             }
           });


### PR DESCRIPTION
Closes #332 

## What does this change?

At the moment if you click _anywhere_ on the screen on a mobile, it sets the focus to the menu button. This is because we are not checking to only call the close offCanvas function if the offcanvas region is open.

## How to test
Visit any microsite page. Reduce the screensize to mobile size. Click somewhere in the body of the page, you'll see they focus goes back to the 'Menu' button.

Checkout this branch, it should be fixed.

## How can we measure success?

You can focus inputs on mobile.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.