### PR TITLE
Check to see if off canvas region is expanded before firing close han…

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -63,7 +63,8 @@
             if (
               offCanvasToggle &&
               !offCanvasToggle.contains(e.target) &&
-              !offCanvas.contains(e.target)
+              !offCanvas.contains(e.target) &&
+              offCanvas.getAttribute('data-expanded') === 'true'
             ) {
               handleCloseOffCanvas();
             }


### PR DESCRIPTION
…dler.



## What does this change?

Checks to see if the off-canvas region is expanded before firing the close handler.

## How to test

Right now, on a microsite, a click anywhere will fire the close handler, and focus jumps to the burger menu.

With this change, the close handler only fires if offCanvas is expanded, i.e. the mobile menu is active.

## How can we measure success?

No unexpected jump to the top of the screen.



## Images

No visual change.

## Accessibility

Unaffected.