### PR TITLE
Fix/337 optional label radio checkbox

### DIFF
--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -142,8 +142,6 @@ body {
   --button-border-color: var(--color-accent-contrast);
   --input-border: 2px solid var(--color-text);
   --input-border-color: var(--color-text);
-  --form-item-required-pseudocontent: "";
-  --form-item-optional-pseudocontent: " (optional)";
 
   /* Applying variables for Page Sections */
   --color-page-section-background-color-1: var(--color-accent);

--- a/css/components/forms.css
+++ b/css/components/forms.css
@@ -5,11 +5,6 @@
 .webform-submission-form .form-required::after {
   display: inline-block;
   padding: 0 var(--spacing-smallest);
-  content: var(--form-item-required-pseudocontent);
-}
-
-.webform-submission-form .form-item label:not(.form-required)::after {
-  content: var(--form-item-optional-pseudocontent);
 }
 
 .webform-confirmation {

--- a/localgov_microsites_base.theme
+++ b/localgov_microsites_base.theme
@@ -13,502 +13,502 @@ use Drupal\views\ViewExecutable;
  */
 function localgov_microsites_base_preprocess_html(&$variables) {
 
-  // Load the group by context. See localgov_microsites_group.module.
-  $group = localgov_microsites_group_get_by_context();
-
-  if ($group instanceof MicrositeGroupInterface) {
-
-    $path_to_theme = '/' . \Drupal::service('extension.list.theme')->getPath('localgov_microsites_base');
-
-    // Adds classes that can be used to let CSS target specific microsites.
-    $variables['attributes']['class'][] = 'lgd-ms';
-    $variables['attributes']['class'][] = 'lgd-ms--' . $group->id();
-
-    // Styleguide primary colour.
-    if (!is_null($group->get('lgms_primary_colour')[0])) {
-      $primary_colour = $group->get('lgms_primary_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--color-accent: ' . $primary_colour . ';';
-    }
-
-    if (!is_null($group->get('lgms_primary_colour_contrast')[0])) {
-      $primary_colour_contrast = $group->get('lgms_primary_colour_contrast')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--color-accent-contrast: ' . $primary_colour_contrast . ';';
-    }
-
-    // Styleguide secondary colour.
-    if (!is_null($group->get('lgms_secondary_colour')[0])) {
-      $secondary_colour = $group->get('lgms_secondary_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--color-accent-2: ' . $secondary_colour . ';';
-    }
-
-    if (!is_null($group->get('lgms_secondary_colour_contrast')[0])) {
-      $secondary_colour_contrast = $group->get('lgms_secondary_colour_contrast')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--color-accent-2-contrast: ' . $secondary_colour_contrast . ';';
-    }
-
-    // Styleguide page background colour.
-    if (!is_null($group->get('lgms_page_background_colour')[0])) {
-      $page_background_colour = $group->get('lgms_page_background_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--page-background-color: ' . $page_background_colour . ';';
-      $variables['attributes']['style'][] = '--breadcrumbs-background-color: ' . $page_background_colour . ';';
-    }
-
-    // Styleguide base spacing.
-    if (!is_null($group->get('lgms_base_spacing')[0])) {
-      $spacing = $group->get('lgms_base_spacing')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--spacing: ' . $spacing . ';';
-    }
-
-    // Styleguide text colour.
-    if (!is_null($group->get('lgms_text_colour')[0])) {
-      $text_colour = $group->get('lgms_text_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--color-text: ' . $text_colour . ';';
-    }
-
-    // Styleguide link colour.
-    if (!is_null($group->get('lgms_link_colour')[0])) {
-      $link_colour = $group->get('lgms_link_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--color-link: ' . $link_colour . ';';
-    }
-
-    // Styleguide heading font.
-    if (!is_null($group->get('lgms_heading_font')[0])) {
-      $heading_font = $group->get('lgms_heading_font')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--font-secondary: '$heading_font';";
-    }
-
-    // Styleguide heading font weight.
-    if (!is_null($group->get('lgms_heading_font_weight')[0])) {
-      $heading_font_weight = $group->get('lgms_heading_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--heading-font-weight: $heading_font_weight;";
-    }
-
-    // Styleguide font-size.
-    if (!is_null($group->get('lgms_base_font_size')[0])) {
-      $font_size = $group->get('lgms_base_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--font-size: ' . $font_size . ';';
-    }
-
-    // Styleguide body font.
-    if (!is_null($group->get('lgms_body_font')[0])) {
-      $body_font = $group->get('lgms_body_font')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--font-primary: '$body_font';";
-    }
-
-    // Styleguide line-height.
-    if (!is_null($group->get('lgms_base_line_height')[0])) {
-      $line_height = $group->get('lgms_base_line_height')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--line-height: ' . $line_height . ';';
-    }
-
-    // Heading Overrides heading 1 font.
-    if (!is_null($group->get('lgms_heading_1_font')[0])) {
-      $heading_1_font = $group->get('lgms_heading_1_font')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--font-heading-1: '$heading_1_font';";
-    }
-
-    // Heading Overrides heading 2 font.
-    if (!is_null($group->get('lgms_heading_2_font')[0])) {
-      $heading_2_font = $group->get('lgms_heading_2_font')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--font-heading-2: '$heading_2_font';";
-    }
-
-    // Heading Overrides heading 3 font.
-    if (!is_null($group->get('lgms_heading_3_font')[0])) {
-      $heading_3_font = $group->get('lgms_heading_3_font')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--font-heading-3: '$heading_3_font';";
-    }
-
-    // Heading Overrides heading 4 font.
-    if (!is_null($group->get('lgms_heading_4_font')[0])) {
-      $heading_4_font = $group->get('lgms_heading_4_font')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--font-heading-4: '$heading_4_font';";
-    }
-
-    // Heading Overrides heading 5 font.
-    if (!is_null($group->get('lgms_heading_5_font')[0])) {
-      $heading_5_font = $group->get('lgms_heading_5_font')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--font-heading-5: '$heading_5_font';";
-    }
-
-    // Heading Overrides heading 6 font.
-    if (!is_null($group->get('lgms_heading_6_font')[0])) {
-      $heading_6_font = $group->get('lgms_heading_6_font')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = "--font-heading-6: '$heading_6_font';";
-    }
-
-    // Heading Overrides heading 1 font weight.
-    if (!is_null($group->get('lgms_heading_1_font_weight')[0])) {
-      $font_weight = $group->get('lgms_heading_1_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-1-font-weight:' . $font_weight . ';';
-    }
-
-    // Heading Overrides heading 2 font weight.
-    if (!is_null($group->get('lgms_heading_2_font_weight')[0])) {
-      $font_weight = $group->get('lgms_heading_2_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-2-font-weight:' . $font_weight . ';';
-    }
-
-    // Heading Overrides heading 3 font weight.
-    if (!is_null($group->get('lgms_heading_3_font_weight')[0])) {
-      $font_weight = $group->get('lgms_heading_3_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-3-font-weight:' . $font_weight . ';';
-    }
-
-    // Heading Overrides heading 4 font weight.
-    if (!is_null($group->get('lgms_heading_4_font_weight')[0])) {
-      $font_weight = $group->get('lgms_heading_4_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-4-font-weight:' . $font_weight . ';';
-    }
-
-    // Heading Overrides heading 5 font weight.
-    if (!is_null($group->get('lgms_heading_5_font_weight')[0])) {
-      $font_weight = $group->get('lgms_heading_5_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-5-font-weight:' . $font_weight . ';';
-    }
-
-    // Heading Overrides heading 6 font weight.
-    if (!is_null($group->get('lgms_heading_6_font_weight')[0])) {
-      $font_weight = $group->get('lgms_heading_6_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-6-font-weight:' . $font_weight . ';';
-    }
-
-    // Heading Overrides heading 1 font colour.
-    if (!is_null($group->get('lgms_heading_1_font_colour')[0])) {
-      $font_colour = $group->get('lgms_heading_1_font_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-1-color: ' . $font_colour . ';';
-    }
-
-    // Heading Overrides heading 2 font colour.
-    if (!is_null($group->get('lgms_heading_2_font_colour')[0])) {
-      $font_colour = $group->get('lgms_heading_2_font_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-2-color: ' . $font_colour . ';';
-    }
-
-    // Heading Overrides heading 3 font colour.
-    if (!is_null($group->get('lgms_heading_3_font_colour')[0])) {
-      $font_colour = $group->get('lgms_heading_3_font_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-3-color: ' . $font_colour . ';';
-    }
-
-    // Heading Overrides heading 4 font colour.
-    if (!is_null($group->get('lgms_heading_4_font_colour')[0])) {
-      $font_colour = $group->get('lgms_heading_4_font_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-4-color: ' . $font_colour . ';';
-    }
-
-    // Heading Overrides heading 5 font colour.
-    if (!is_null($group->get('lgms_heading_5_font_colour')[0])) {
-      $font_colour = $group->get('lgms_heading_5_font_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-5-color: ' . $font_colour . ';';
-    }
-
-    // Heading Overrides heading 6 font colour.
-    if (!is_null($group->get('lgms_heading_6_font_colour')[0])) {
-      $font_colour = $group->get('lgms_heading_6_font_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-6-color: ' . $font_colour . ';';
-    }
-
-    // Heading Overrides heading 1 line height.
-    if (!is_null($group->get('lgms_heading_1_line_height')[0])) {
-      $line_height = $group->get('lgms_heading_1_line_height')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-1-line-height: ' . $line_height . ';';
-    }
-
-    // Heading Overrides heading 2 line height.
-    if (!is_null($group->get('lgms_heading_2_line_height')[0])) {
-      $line_height = $group->get('lgms_heading_2_line_height')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-2-line-height: ' . $line_height . ';';
-    }
-
-    // Heading Overrides heading 3 line height.
-    if (!is_null($group->get('lgms_heading_3_line_height')[0])) {
-      $line_height = $group->get('lgms_heading_3_line_height')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-3-line-height: ' . $line_height . ';';
-    }
-
-    // Heading Overrides heading 4 line height.
-    if (!is_null($group->get('lgms_heading_4_line_height')[0])) {
-      $line_height = $group->get('lgms_heading_4_line_height')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-4-line-height: ' . $line_height . ';';
-    }
-
-    // Heading Overrides heading 5 line height.
-    if (!is_null($group->get('lgms_heading_5_line_height')[0])) {
-      $line_height = $group->get('lgms_heading_5_line_height')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-5-line-height: ' . $line_height . ';';
-    }
-
-    // Heading Overrides heading 6 line height.
-    if (!is_null($group->get('lgms_heading_6_line_height')[0])) {
-      $line_height = $group->get('lgms_heading_6_line_height')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--heading-6-line-height: ' . $line_height . ';';
-    }
-
-    // Heading Overrides heading 1 font-size.
-    if (!is_null($group->get('lgms_heading_1_font_size')[0])) {
-      $font_size = $group->get('lgms_heading_1_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--font-size-largest: ' . $font_size . ';';
-    }
-
-    // Heading Overrides heading 2 font-size.
-    if (!is_null($group->get('lgms_heading_2_font_size')[0])) {
-      $font_size = $group->get('lgms_heading_2_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--font-size-larger: ' . $font_size . ';';
-    }
-
-    // Heading Overrides heading 3 font-size.
-    if (!is_null($group->get('lgms_heading_3_font_size')[0])) {
-      $font_size = $group->get('lgms_heading_3_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--font-size-large: ' . $font_size . ';';
-    }
-
-    // Heading Overrides heading 4 font-size.
-    if (!is_null($group->get('lgms_heading_4_font_size')[0])) {
-      $font_size = $group->get('lgms_heading_4_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--font-size-h4: ' . $font_size . ';';
-    }
-
-    // Heading Overrides heading 5 font-size.
-    if (!is_null($group->get('lgms_heading_5_font_size')[0])) {
-      $font_size = $group->get('lgms_heading_5_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--font-size-h5: ' . $font_size . ';';
-    }
-
-    // Heading Overrides heading 6 font-size.
-    if (!is_null($group->get('lgms_heading_6_font_size')[0])) {
-      $font_size = $group->get('lgms_heading_6_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--font-size-h6: ' . $font_size . ';';
-    }
-
-    // Pre-header Background colour.
-    if (!is_null($group->get('lgms_pre_header_bg_colour')[0])) {
-      $pre_header_background_colour = $group->get('lgms_pre_header_bg_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--pre-header-background-color: ' . $pre_header_background_colour . ';';
-    }
-
-    // Pre-header text colour.
-    if (!is_null($group->get('lgms_pre_header_text_colour')[0])) {
-      $pre_header_text_colour = $group->get('lgms_pre_header_text_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--pre-header-text-color: ' . $pre_header_text_colour . ';';
-    }
-
-    // Pre-header link colour.
-    if (!is_null($group->get('lgms_pre_header_link_colour')[0])) {
-      $pre_header_link_colour = $group->get('lgms_pre_header_link_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--pre-header-link-color: ' . $pre_header_link_colour . ';';
-    }
-
-    // Pre-header link hover state colour.
-    if (!is_null($group->get('lgms_pre_header_link_hover')[0])) {
-      $pre_header_link_hover_colour = $group->get('lgms_pre_header_link_hover')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--pre-header-link-hover-color: ' . $pre_header_link_hover_colour . ';';
-    }
-
-    // Header Background colour.
-    if (!is_null($group->get('lgms_header_bg_colour')[0])) {
-      $header_background_colour = $group->get('lgms_header_bg_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--header-background-color: ' . $header_background_colour . ';';
-    }
-
-    // Header text colour.
-    if (!is_null($group->get('lgms_header_text_colour')[0])) {
-      $header_text_colour = $group->get('lgms_header_text_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--header-text-color: ' . $header_text_colour . ';';
-    }
-
-    // Header link colour.
-    if (!is_null($group->get('lgms_header_link_colour')[0])) {
-      $header_link_colour = $group->get('lgms_header_link_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--header-link-color: ' . $header_link_colour . ';';
-    }
-
-    // Header link hover state colour.
-    if (!is_null($group->get('lgms_header_link_hover_colour')[0])) {
-      $header_link_hover_colour = $group->get('lgms_header_link_hover_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--header-link-hover-color: ' . $header_link_hover_colour . ';';
-    }
-
-    // Header site name font size.
-    if (!is_null($group->get('lgms_site_name_font_size')[0])) {
-      $site_name_font_size = $group->get('lgms_site_name_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--site-name-font-size: ' . $site_name_font_size . ';';
-    }
-
-    // Header site name font weight.
-    if (!is_null($group->get('lgms_site_name_font_weight')[0])) {
-      $site_name_font_weight = $group->get('lgms_site_name_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--site-name-font-weight: ' . $site_name_font_weight . ';';
-    }
-
-    // Header vertical alignment.
-    if (!is_null($group->get('lgms_header_vertical_alignment')[0])) {
-      $header_vertical_alignment = $group->get('lgms_header_vertical_alignment')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--header-items-alignment: ' . $header_vertical_alignment . ';';
-    }
-
-    // Main menu site font size.
-    if (!is_null($group->get('lgms_main_menu_font_size')[0])) {
-      $main_menu_font_size = $group->get('lgms_main_menu_font_size')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--menu-main-font-size: ' . $main_menu_font_size . ';';
-    }
-
-    // Main menu site font weight.
-    if (!is_null($group->get('lgms_main_menu_font_weight')[0])) {
-      $main_menu_font_weight = $group->get('lgms_main_menu_font_weight')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--menu-main-font-weight: ' . $main_menu_font_weight . ';';
-    }
-
-    // Main menu submenu background colour.
-    if (!is_null($group->get('lgms_submenu_background_colour')[0])) {
-      $submenu_background_colour = $group->get('lgms_submenu_background_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--menu-sub-menu-background-colour: ' . $submenu_background_colour . ';';
-    }
-
-    // Main menu submenu text colour.
-    if (!is_null($group->get('lgms_submenu_link_colour')[0])) {
-      $submenu_link_colour = $group->get('lgms_submenu_link_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--menu-sub-menu-link-colour: ' . $submenu_link_colour . ';';
-    }
-
-    // Main menu submenu icon.
-    if (!is_null($group->get('lgms_submenu_icon')[0])) {
-      $submenu_icon = $group->get('lgms_submenu_icon')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--menu-sub-menu-icon: url(' . $path_to_theme . '/includes/icons/' . $submenu_icon . '.svg) ;';
-    }
-
-    // Main menu submenu icon rotation.
-    if (!is_null($group->get('lgms_submenu_icon_rotation')[0])) {
-      $submenu_icon_rotation = $group->get('lgms_submenu_icon_rotation')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--menu-item-toggle-icon-rotation:' . $submenu_icon_rotation . ';';
-    }
-
-    // Off canvas menu icon.
-    if (!is_null($group->get('lgms_off_canvas_menu_icon')[0])) {
-      $off_canvas_menu_icon = $group->get('lgms_off_canvas_menu_icon')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--off-canvas-menu-icon: url(' . $path_to_theme . '/includes/icons/' . $off_canvas_menu_icon . '.svg) ;';
-    }
-
-    // Off canvas background colour.
-    if (!is_null($group->get('lgms_off_canvas_bg_colour')[0])) {
-      $off_canvas_bg_colour = $group->get('lgms_off_canvas_bg_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--off-canvas-background-color: ' . $off_canvas_bg_colour . ';';
-    }
-
-    // Off canvas text colour.
-    if (!is_null($group->get('lgms_off_canvas_text_colour')[0])) {
-      $off_canvas_text_colour = $group->get('lgms_off_canvas_text_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--off-canvas-link-color: ' . $off_canvas_text_colour . ';';
-    }
-
-    // Footer background colour.
-    if (!is_null($group->get('lgms_footer_background_colour')[0])) {
-      $footer_background_colour = $group->get('lgms_footer_background_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--footer-background-color: ' . $footer_background_colour . ';';
-    }
-
-    // Footer text colour.
-    if (!is_null($group->get('lgms_footer_text_colour')[0])) {
-      $footer_text_colour = $group->get('lgms_footer_text_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--footer-text-color: ' . $footer_text_colour . ';';
-    }
-
-    // Footer link colour.
-    if (!is_null($group->get('lgms_footer_link_colour')[0])) {
-      $footer_link_colour = $group->get('lgms_footer_link_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--footer-link-color: ' . $footer_link_colour . ';';
-    }
-
-    // Footer link hover state colour.
-    if (!is_null($group->get('lgms_footer_link_hover_colour')[0])) {
-      $footer_link_hover_colour = $group->get('lgms_footer_link_hover_colour')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--footer-link-hover-color: ' . $footer_link_hover_colour . ';';
-    }
-
-    // Header vertical alignment.
-    if (!is_null($group->get('lgms_footer_items_alignment')[0])) {
-      $footer_items_alignment = $group->get('lgms_footer_items_alignment')[0]->getValue()['value'];
-      $variables['attributes']['style'][] = '--footer-grid-column-justification: ' . $footer_items_alignment . ';';
+    // Load the group by context. See localgov_microsites_group.module.
+    $group = localgov_microsites_group_get_by_context();
+
+    if ($group instanceof MicrositeGroupInterface) {
+
+        $path_to_theme = '/' . \Drupal::service('extension.list.theme')->getPath('localgov_microsites_base');
+
+        // Adds classes that can be used to let CSS target specific microsites.
+        $variables['attributes']['class'][] = 'lgd-ms';
+        $variables['attributes']['class'][] = 'lgd-ms--' . $group->id();
+
+        // Styleguide primary colour.
+        if (!is_null($group->get('lgms_primary_colour')[0])) {
+            $primary_colour = $group->get('lgms_primary_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--color-accent: ' . $primary_colour . ';';
+        }
+
+        if (!is_null($group->get('lgms_primary_colour_contrast')[0])) {
+            $primary_colour_contrast = $group->get('lgms_primary_colour_contrast')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--color-accent-contrast: ' . $primary_colour_contrast . ';';
+        }
+
+        // Styleguide secondary colour.
+        if (!is_null($group->get('lgms_secondary_colour')[0])) {
+            $secondary_colour = $group->get('lgms_secondary_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--color-accent-2: ' . $secondary_colour . ';';
+        }
+
+        if (!is_null($group->get('lgms_secondary_colour_contrast')[0])) {
+            $secondary_colour_contrast = $group->get('lgms_secondary_colour_contrast')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--color-accent-2-contrast: ' . $secondary_colour_contrast . ';';
+        }
+
+        // Styleguide page background colour.
+        if (!is_null($group->get('lgms_page_background_colour')[0])) {
+            $page_background_colour = $group->get('lgms_page_background_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--page-background-color: ' . $page_background_colour . ';';
+            $variables['attributes']['style'][] = '--breadcrumbs-background-color: ' . $page_background_colour . ';';
+        }
+
+        // Styleguide base spacing.
+        if (!is_null($group->get('lgms_base_spacing')[0])) {
+            $spacing = $group->get('lgms_base_spacing')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--spacing: ' . $spacing . ';';
+        }
+
+        // Styleguide text colour.
+        if (!is_null($group->get('lgms_text_colour')[0])) {
+            $text_colour = $group->get('lgms_text_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--color-text: ' . $text_colour . ';';
+        }
+
+        // Styleguide link colour.
+        if (!is_null($group->get('lgms_link_colour')[0])) {
+            $link_colour = $group->get('lgms_link_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--color-link: ' . $link_colour . ';';
+        }
+
+        // Styleguide heading font.
+        if (!is_null($group->get('lgms_heading_font')[0])) {
+            $heading_font = $group->get('lgms_heading_font')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--font-secondary: '$heading_font';";
+        }
+
+        // Styleguide heading font weight.
+        if (!is_null($group->get('lgms_heading_font_weight')[0])) {
+            $heading_font_weight = $group->get('lgms_heading_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--heading-font-weight: $heading_font_weight;";
+        }
+
+        // Styleguide font-size.
+        if (!is_null($group->get('lgms_base_font_size')[0])) {
+            $font_size = $group->get('lgms_base_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--font-size: ' . $font_size . ';';
+        }
+
+        // Styleguide body font.
+        if (!is_null($group->get('lgms_body_font')[0])) {
+            $body_font = $group->get('lgms_body_font')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--font-primary: '$body_font';";
+        }
+
+        // Styleguide line-height.
+        if (!is_null($group->get('lgms_base_line_height')[0])) {
+            $line_height = $group->get('lgms_base_line_height')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--line-height: ' . $line_height . ';';
+        }
+
+        // Heading Overrides heading 1 font.
+        if (!is_null($group->get('lgms_heading_1_font')[0])) {
+            $heading_1_font = $group->get('lgms_heading_1_font')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--font-heading-1: '$heading_1_font';";
+        }
+
+        // Heading Overrides heading 2 font.
+        if (!is_null($group->get('lgms_heading_2_font')[0])) {
+            $heading_2_font = $group->get('lgms_heading_2_font')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--font-heading-2: '$heading_2_font';";
+        }
+
+        // Heading Overrides heading 3 font.
+        if (!is_null($group->get('lgms_heading_3_font')[0])) {
+            $heading_3_font = $group->get('lgms_heading_3_font')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--font-heading-3: '$heading_3_font';";
+        }
+
+        // Heading Overrides heading 4 font.
+        if (!is_null($group->get('lgms_heading_4_font')[0])) {
+            $heading_4_font = $group->get('lgms_heading_4_font')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--font-heading-4: '$heading_4_font';";
+        }
+
+        // Heading Overrides heading 5 font.
+        if (!is_null($group->get('lgms_heading_5_font')[0])) {
+            $heading_5_font = $group->get('lgms_heading_5_font')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--font-heading-5: '$heading_5_font';";
+        }
+
+        // Heading Overrides heading 6 font.
+        if (!is_null($group->get('lgms_heading_6_font')[0])) {
+            $heading_6_font = $group->get('lgms_heading_6_font')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = "--font-heading-6: '$heading_6_font';";
+        }
+
+        // Heading Overrides heading 1 font weight.
+        if (!is_null($group->get('lgms_heading_1_font_weight')[0])) {
+            $font_weight = $group->get('lgms_heading_1_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-1-font-weight:' . $font_weight . ';';
+        }
+
+        // Heading Overrides heading 2 font weight.
+        if (!is_null($group->get('lgms_heading_2_font_weight')[0])) {
+            $font_weight = $group->get('lgms_heading_2_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-2-font-weight:' . $font_weight . ';';
+        }
+
+        // Heading Overrides heading 3 font weight.
+        if (!is_null($group->get('lgms_heading_3_font_weight')[0])) {
+            $font_weight = $group->get('lgms_heading_3_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-3-font-weight:' . $font_weight . ';';
+        }
+
+        // Heading Overrides heading 4 font weight.
+        if (!is_null($group->get('lgms_heading_4_font_weight')[0])) {
+            $font_weight = $group->get('lgms_heading_4_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-4-font-weight:' . $font_weight . ';';
+        }
+
+        // Heading Overrides heading 5 font weight.
+        if (!is_null($group->get('lgms_heading_5_font_weight')[0])) {
+            $font_weight = $group->get('lgms_heading_5_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-5-font-weight:' . $font_weight . ';';
+        }
+
+        // Heading Overrides heading 6 font weight.
+        if (!is_null($group->get('lgms_heading_6_font_weight')[0])) {
+            $font_weight = $group->get('lgms_heading_6_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-6-font-weight:' . $font_weight . ';';
+        }
+
+        // Heading Overrides heading 1 font colour.
+        if (!is_null($group->get('lgms_heading_1_font_colour')[0])) {
+            $font_colour = $group->get('lgms_heading_1_font_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-1-color: ' . $font_colour . ';';
+        }
+
+        // Heading Overrides heading 2 font colour.
+        if (!is_null($group->get('lgms_heading_2_font_colour')[0])) {
+            $font_colour = $group->get('lgms_heading_2_font_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-2-color: ' . $font_colour . ';';
+        }
+
+        // Heading Overrides heading 3 font colour.
+        if (!is_null($group->get('lgms_heading_3_font_colour')[0])) {
+            $font_colour = $group->get('lgms_heading_3_font_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-3-color: ' . $font_colour . ';';
+        }
+
+        // Heading Overrides heading 4 font colour.
+        if (!is_null($group->get('lgms_heading_4_font_colour')[0])) {
+            $font_colour = $group->get('lgms_heading_4_font_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-4-color: ' . $font_colour . ';';
+        }
+
+        // Heading Overrides heading 5 font colour.
+        if (!is_null($group->get('lgms_heading_5_font_colour')[0])) {
+            $font_colour = $group->get('lgms_heading_5_font_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-5-color: ' . $font_colour . ';';
+        }
+
+        // Heading Overrides heading 6 font colour.
+        if (!is_null($group->get('lgms_heading_6_font_colour')[0])) {
+            $font_colour = $group->get('lgms_heading_6_font_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-6-color: ' . $font_colour . ';';
+        }
+
+        // Heading Overrides heading 1 line height.
+        if (!is_null($group->get('lgms_heading_1_line_height')[0])) {
+            $line_height = $group->get('lgms_heading_1_line_height')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-1-line-height: ' . $line_height . ';';
+        }
+
+        // Heading Overrides heading 2 line height.
+        if (!is_null($group->get('lgms_heading_2_line_height')[0])) {
+            $line_height = $group->get('lgms_heading_2_line_height')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-2-line-height: ' . $line_height . ';';
+        }
+
+        // Heading Overrides heading 3 line height.
+        if (!is_null($group->get('lgms_heading_3_line_height')[0])) {
+            $line_height = $group->get('lgms_heading_3_line_height')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-3-line-height: ' . $line_height . ';';
+        }
+
+        // Heading Overrides heading 4 line height.
+        if (!is_null($group->get('lgms_heading_4_line_height')[0])) {
+            $line_height = $group->get('lgms_heading_4_line_height')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-4-line-height: ' . $line_height . ';';
+        }
+
+        // Heading Overrides heading 5 line height.
+        if (!is_null($group->get('lgms_heading_5_line_height')[0])) {
+            $line_height = $group->get('lgms_heading_5_line_height')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-5-line-height: ' . $line_height . ';';
+        }
+
+        // Heading Overrides heading 6 line height.
+        if (!is_null($group->get('lgms_heading_6_line_height')[0])) {
+            $line_height = $group->get('lgms_heading_6_line_height')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--heading-6-line-height: ' . $line_height . ';';
+        }
+
+        // Heading Overrides heading 1 font-size.
+        if (!is_null($group->get('lgms_heading_1_font_size')[0])) {
+            $font_size = $group->get('lgms_heading_1_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--font-size-largest: ' . $font_size . ';';
+        }
+
+        // Heading Overrides heading 2 font-size.
+        if (!is_null($group->get('lgms_heading_2_font_size')[0])) {
+            $font_size = $group->get('lgms_heading_2_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--font-size-larger: ' . $font_size . ';';
+        }
+
+        // Heading Overrides heading 3 font-size.
+        if (!is_null($group->get('lgms_heading_3_font_size')[0])) {
+            $font_size = $group->get('lgms_heading_3_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--font-size-large: ' . $font_size . ';';
+        }
+
+        // Heading Overrides heading 4 font-size.
+        if (!is_null($group->get('lgms_heading_4_font_size')[0])) {
+            $font_size = $group->get('lgms_heading_4_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--font-size-h4: ' . $font_size . ';';
+        }
+
+        // Heading Overrides heading 5 font-size.
+        if (!is_null($group->get('lgms_heading_5_font_size')[0])) {
+            $font_size = $group->get('lgms_heading_5_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--font-size-h5: ' . $font_size . ';';
+        }
+
+        // Heading Overrides heading 6 font-size.
+        if (!is_null($group->get('lgms_heading_6_font_size')[0])) {
+            $font_size = $group->get('lgms_heading_6_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--font-size-h6: ' . $font_size . ';';
+        }
+
+        // Pre-header Background colour.
+        if (!is_null($group->get('lgms_pre_header_bg_colour')[0])) {
+            $pre_header_background_colour = $group->get('lgms_pre_header_bg_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--pre-header-background-color: ' . $pre_header_background_colour . ';';
+        }
+
+        // Pre-header text colour.
+        if (!is_null($group->get('lgms_pre_header_text_colour')[0])) {
+            $pre_header_text_colour = $group->get('lgms_pre_header_text_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--pre-header-text-color: ' . $pre_header_text_colour . ';';
+        }
+
+        // Pre-header link colour.
+        if (!is_null($group->get('lgms_pre_header_link_colour')[0])) {
+            $pre_header_link_colour = $group->get('lgms_pre_header_link_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--pre-header-link-color: ' . $pre_header_link_colour . ';';
+        }
+
+        // Pre-header link hover state colour.
+        if (!is_null($group->get('lgms_pre_header_link_hover')[0])) {
+            $pre_header_link_hover_colour = $group->get('lgms_pre_header_link_hover')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--pre-header-link-hover-color: ' . $pre_header_link_hover_colour . ';';
+        }
+
+        // Header Background colour.
+        if (!is_null($group->get('lgms_header_bg_colour')[0])) {
+            $header_background_colour = $group->get('lgms_header_bg_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--header-background-color: ' . $header_background_colour . ';';
+        }
+
+        // Header text colour.
+        if (!is_null($group->get('lgms_header_text_colour')[0])) {
+            $header_text_colour = $group->get('lgms_header_text_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--header-text-color: ' . $header_text_colour . ';';
+        }
+
+        // Header link colour.
+        if (!is_null($group->get('lgms_header_link_colour')[0])) {
+            $header_link_colour = $group->get('lgms_header_link_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--header-link-color: ' . $header_link_colour . ';';
+        }
+
+        // Header link hover state colour.
+        if (!is_null($group->get('lgms_header_link_hover_colour')[0])) {
+            $header_link_hover_colour = $group->get('lgms_header_link_hover_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--header-link-hover-color: ' . $header_link_hover_colour . ';';
+        }
+
+        // Header site name font size.
+        if (!is_null($group->get('lgms_site_name_font_size')[0])) {
+            $site_name_font_size = $group->get('lgms_site_name_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--site-name-font-size: ' . $site_name_font_size . ';';
+        }
+
+        // Header site name font weight.
+        if (!is_null($group->get('lgms_site_name_font_weight')[0])) {
+            $site_name_font_weight = $group->get('lgms_site_name_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--site-name-font-weight: ' . $site_name_font_weight . ';';
+        }
+
+        // Header vertical alignment.
+        if (!is_null($group->get('lgms_header_vertical_alignment')[0])) {
+            $header_vertical_alignment = $group->get('lgms_header_vertical_alignment')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--header-items-alignment: ' . $header_vertical_alignment . ';';
+        }
+
+        // Main menu site font size.
+        if (!is_null($group->get('lgms_main_menu_font_size')[0])) {
+            $main_menu_font_size = $group->get('lgms_main_menu_font_size')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--menu-main-font-size: ' . $main_menu_font_size . ';';
+        }
+
+        // Main menu site font weight.
+        if (!is_null($group->get('lgms_main_menu_font_weight')[0])) {
+            $main_menu_font_weight = $group->get('lgms_main_menu_font_weight')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--menu-main-font-weight: ' . $main_menu_font_weight . ';';
+        }
+
+        // Main menu submenu background colour.
+        if (!is_null($group->get('lgms_submenu_background_colour')[0])) {
+            $submenu_background_colour = $group->get('lgms_submenu_background_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--menu-sub-menu-background-colour: ' . $submenu_background_colour . ';';
+        }
+
+        // Main menu submenu text colour.
+        if (!is_null($group->get('lgms_submenu_link_colour')[0])) {
+            $submenu_link_colour = $group->get('lgms_submenu_link_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--menu-sub-menu-link-colour: ' . $submenu_link_colour . ';';
+        }
+
+        // Main menu submenu icon.
+        if (!is_null($group->get('lgms_submenu_icon')[0])) {
+            $submenu_icon = $group->get('lgms_submenu_icon')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--menu-sub-menu-icon: url(' . $path_to_theme . '/includes/icons/' . $submenu_icon . '.svg) ;';
+        }
+
+        // Main menu submenu icon rotation.
+        if (!is_null($group->get('lgms_submenu_icon_rotation')[0])) {
+            $submenu_icon_rotation = $group->get('lgms_submenu_icon_rotation')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--menu-item-toggle-icon-rotation:' . $submenu_icon_rotation . ';';
+        }
+
+        // Off canvas menu icon.
+        if (!is_null($group->get('lgms_off_canvas_menu_icon')[0])) {
+            $off_canvas_menu_icon = $group->get('lgms_off_canvas_menu_icon')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--off-canvas-menu-icon: url(' . $path_to_theme . '/includes/icons/' . $off_canvas_menu_icon . '.svg) ;';
+        }
+
+        // Off canvas background colour.
+        if (!is_null($group->get('lgms_off_canvas_bg_colour')[0])) {
+            $off_canvas_bg_colour = $group->get('lgms_off_canvas_bg_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--off-canvas-background-color: ' . $off_canvas_bg_colour . ';';
+        }
+
+        // Off canvas text colour.
+        if (!is_null($group->get('lgms_off_canvas_text_colour')[0])) {
+            $off_canvas_text_colour = $group->get('lgms_off_canvas_text_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--off-canvas-link-color: ' . $off_canvas_text_colour . ';';
+        }
+
+        // Footer background colour.
+        if (!is_null($group->get('lgms_footer_background_colour')[0])) {
+            $footer_background_colour = $group->get('lgms_footer_background_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--footer-background-color: ' . $footer_background_colour . ';';
+        }
+
+        // Footer text colour.
+        if (!is_null($group->get('lgms_footer_text_colour')[0])) {
+            $footer_text_colour = $group->get('lgms_footer_text_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--footer-text-color: ' . $footer_text_colour . ';';
+        }
+
+        // Footer link colour.
+        if (!is_null($group->get('lgms_footer_link_colour')[0])) {
+            $footer_link_colour = $group->get('lgms_footer_link_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--footer-link-color: ' . $footer_link_colour . ';';
+        }
+
+        // Footer link hover state colour.
+        if (!is_null($group->get('lgms_footer_link_hover_colour')[0])) {
+            $footer_link_hover_colour = $group->get('lgms_footer_link_hover_colour')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--footer-link-hover-color: ' . $footer_link_hover_colour . ';';
+        }
+
+        // Header vertical alignment.
+        if (!is_null($group->get('lgms_footer_items_alignment')[0])) {
+            $footer_items_alignment = $group->get('lgms_footer_items_alignment')[0]->getValue()['value'];
+            $variables['attributes']['style'][] = '--footer-grid-column-justification: ' . $footer_items_alignment . ';';
+        }
     }
-  }
 }
 
 /**
  * Implements hook_preprocess_HOOK().
  */
 function localgov_microsites_base_preprocess_node(&$variables) {
-  $variables['node'] = $variables['elements']['#node'];
-  $variables['view_mode'] = $variables['elements']['#view_mode'];
-  $variables['content_type'] = $variables['node']->getType();
-  $variables['teaser'] = $variables['view_mode'] == 'teaser';
+    $variables['node'] = $variables['elements']['#node'];
+    $variables['view_mode'] = $variables['elements']['#view_mode'];
+    $variables['content_type'] = $variables['node']->getType();
+    $variables['teaser'] = $variables['view_mode'] == 'teaser';
 
-  // Load the group by context. See localgov_microsites_group.module.
-  $group = localgov_microsites_group_get_by_context();
-  $current_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
+    // Load the group by context. See localgov_microsites_group.module.
+    $group = localgov_microsites_group_get_by_context();
+    $current_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
 
-  if ($group instanceof MicrositeGroupInterface) {
-    $front_page = \Drupal::config('domain.config.' . $current_domain->id() . '.system.site')->get('page.front');
-    $current_path = \Drupal::service('path.current')->getPath();
-    $current_path_alias = \Drupal::service('path_alias.manager')->getAliasByPath($current_path);
+    if ($group instanceof MicrositeGroupInterface) {
+        $front_page = \Drupal::config('domain.config.' . $current_domain->id() . '.system.site')->get('page.front');
+        $current_path = \Drupal::service('path.current')->getPath();
+        $current_path_alias = \Drupal::service('path_alias.manager')->getAliasByPath($current_path);
 
-    if (($front_page === $current_path || $front_page === $current_path_alias) && $variables['view_mode'] === 'full') {
-      if (isset($group->get('lgms_hide_title')[0])) {
-        if ($group->get('lgms_hide_title')[0]->getValue()['value'] === "1") {
-          $variables['label']['#markup'] = '<div class="visually-hidden">' . $variables['label']['#markup'] . '</div>';
+        if (($front_page === $current_path || $front_page === $current_path_alias) && $variables['view_mode'] === 'full') {
+            if (isset($group->get('lgms_hide_title')[0])) {
+                if ($group->get('lgms_hide_title')[0]->getValue()['value'] === "1") {
+                    $variables['label']['#markup'] = '<div class="visually-hidden">' . $variables['label']['#markup'] . '</div>';
+                }
+            }
         }
-      }
+
+        if (!is_null($group->get('lgms_teaser_image_style')[0])) {
+            $teaser_image_style = $group->get('lgms_teaser_image_style')[0]->getValue()['value'];
+
+            switch ($teaser_image_style) {
+                case 'square':
+                    $variables['microsites']['advanced']['teaser_image_style'] = 'square_medium';
+                    break;
+
+                case '3x2':
+                    $variables['microsites']['advanced']['teaser_image_style'] = 'medium_3_2_600x400';
+                    break;
+
+                case '7x3':
+                    $variables['microsites']['advanced']['teaser_image_style'] = 'small_21_9';
+                    break;
+            }
+
+            if ($variables['teaser']) {
+                switch ($variables['content_type']) {
+                    case 'localgov_event':
+                        $media_id = $variables['node']->localgov_event_image[0]->getValue()['target_id'];
+                        break;
+
+                    case 'localgov_news_article':
+                        $media_id = $variables['node']->field_media_image[0]->getValue()['target_id'];
+                        break;
+
+                    case 'localgov_blog_post':
+                        $media_id = $variables['node']->field_media_image[0]->getValue()['target_id'];
+                        break;
+
+                    case 'localgov_directory_promo_page':
+                        $banner_paragraph_id = $variables['node']->localgov_directory_banner[0]->getValue()['target_id'];
+                        $banner_paragraph = \Drupal::entityTypeManager()->getStorage('paragraph')->load($banner_paragraph_id);
+                        $media_id = $banner_paragraph->localgov_image[0]->getValue()['target_id'];
+                        break;
+                }
+                if (isset($media_id)) {
+                    $teaser_image_field = \Drupal::entityTypeManager()->getStorage('media')->load($media_id);
+                    $variables['microsites']['advanced']['teaser_image'] = $teaser_image_field->field_media_image->view([
+                        'type' => 'image',
+                        'label' => 'hidden',
+                        'settings' => [
+                            'image_style' => $variables['microsites']['advanced']['teaser_image_style'],
+                        ],
+                    ]);
+                }
+            }
+        }
     }
-
-    if (!is_null($group->get('lgms_teaser_image_style')[0])) {
-      $teaser_image_style = $group->get('lgms_teaser_image_style')[0]->getValue()['value'];
-
-      switch ($teaser_image_style) {
-        case 'square':
-          $variables['microsites']['advanced']['teaser_image_style'] = 'square_medium';
-          break;
-
-        case '3x2':
-          $variables['microsites']['advanced']['teaser_image_style'] = 'medium_3_2_600x400';
-          break;
-
-        case '7x3':
-          $variables['microsites']['advanced']['teaser_image_style'] = 'small_21_9';
-          break;
-      }
-
-      if ($variables['teaser']) {
-        switch ($variables['content_type']) {
-          case 'localgov_event':
-            $media_id = $variables['node']->localgov_event_image[0]->getValue()['target_id'];
-            break;
-
-          case 'localgov_news_article':
-            $media_id = $variables['node']->field_media_image[0]->getValue()['target_id'];
-            break;
-
-          case 'localgov_blog_post':
-            $media_id = $variables['node']->field_media_image[0]->getValue()['target_id'];
-            break;
-
-          case 'localgov_directory_promo_page':
-            $banner_paragraph_id = $variables['node']->localgov_directory_banner[0]->getValue()['target_id'];
-            $banner_paragraph = \Drupal::entityTypeManager()->getStorage('paragraph')->load($banner_paragraph_id);
-            $media_id = $banner_paragraph->localgov_image[0]->getValue()['target_id'];
-            break;
-        }
-        if (isset($media_id)) {
-          $teaser_image_field = \Drupal::entityTypeManager()->getStorage('media')->load($media_id);
-          $variables['microsites']['advanced']['teaser_image'] = $teaser_image_field->field_media_image->view([
-            'type' => 'image',
-            'label' => 'hidden',
-            'settings' => [
-              'image_style' => $variables['microsites']['advanced']['teaser_image_style'],
-            ],
-          ]);
-        }
-      }
-    }
-  }
 
 }
 
@@ -517,42 +517,42 @@ function localgov_microsites_base_preprocess_node(&$variables) {
  */
 function localgov_microsites_base_views_pre_render(ViewExecutable $view) {
 
-  if ($view->id() === 'localgov_events_listing' && $view->current_display === 'page_all_events' || $view->id() === 'lgms_embed_view_events' && $view->current_display === 'upcoming_events') {
+    if ($view->id() === 'localgov_events_listing' && $view->current_display === 'page_all_events' || $view->id() === 'lgms_embed_view_events' && $view->current_display === 'upcoming_events') {
 
-    $view->element['#attached']['library'][] = 'localgov_microsites_base/view-events';
+        $view->element['#attached']['library'][] = 'localgov_microsites_base/view-events';
 
-    // Load the group by context. See localgov_microsites_group.module.
-    $group = localgov_microsites_group_get_by_context();
+        // Load the group by context. See localgov_microsites_group.module.
+        $group = localgov_microsites_group_get_by_context();
 
-    if (!is_null($group) && !empty($group->get('lgms_teaser_image_style')->getValue())) {
+        if (!is_null($group) && !empty($group->get('lgms_teaser_image_style')->getValue())) {
 
-      $teaser_image_style = $group->get('lgms_teaser_image_style')[0]->getValue()['value'];
-      switch ($teaser_image_style) {
-        case 'square':
-          $image_style = 'square_medium';
-          break;
+            $teaser_image_style = $group->get('lgms_teaser_image_style')[0]->getValue()['value'];
+            switch ($teaser_image_style) {
+                case 'square':
+                    $image_style = 'square_medium';
+                    break;
 
-        case '3x2':
-          $image_style = 'manual_3_2_crop';
-          break;
+                case '3x2':
+                    $image_style = 'manual_3_2_crop';
+                    break;
 
-        case '7x3':
-          $image_style = 'manual_7_3_crop';
-          break;
-      }
+                case '7x3':
+                    $image_style = 'manual_7_3_crop';
+                    break;
+            }
 
-      // Set image to display as thumbnail.
-      $image_field = $view->field['localgov_event_image'];
-      $image_field->options['type'] = 'media_thumbnail';
-      $image_field->options['settings'] = [
-        'image_link' => '',
-        'image_style' => $image_style,
-        'image_loading' => [
-          'attribute' => 'lazy',
-        ],
-      ];
+            // Set image to display as thumbnail.
+            $image_field = $view->field['localgov_event_image'];
+            $image_field->options['type'] = 'media_thumbnail';
+            $image_field->options['settings'] = [
+                'image_link' => '',
+                'image_style' => $image_style,
+                'image_loading' => [
+                    'attribute' => 'lazy',
+                ],
+            ];
+        }
     }
-  }
 }
 
 /**
@@ -560,132 +560,248 @@ function localgov_microsites_base_views_pre_render(ViewExecutable $view) {
  */
 function localgov_microsites_base_preprocess_page(&$variables) {
 
-  // Load the site name out of configuration.
-  $config = \Drupal::config('system.site');
-  $variables['site_name'] = $config->get('name');
-  $variables['site_slogan'] = $config->get('slogan');
+    // Load the site name out of configuration.
+    $config = \Drupal::config('system.site');
+    $variables['site_name'] = $config->get('name');
+    $variables['site_slogan'] = $config->get('slogan');
 
-  // Load the group by context. See localgov_microsites_group.module.
-  $group = localgov_microsites_group_get_by_context();
+    // Load the group by context. See localgov_microsites_group.module.
+    $group = localgov_microsites_group_get_by_context();
 
-  if ($group instanceof MicrositeGroupInterface) {
+    if ($group instanceof MicrositeGroupInterface) {
 
-    // Header.
-    if (!empty($group->get('lgms_header_width')->getValue())) {
-      $width = $group->get('lgms_header_width')->getValue()[0]['value'];
-      switch ($width) {
-        case 'full-width':
-          $variables['microsites']['header']['width']['full_width'] = TRUE;
-          break;
+        // Header.
+        if (!empty($group->get('lgms_header_width')->getValue())) {
+            $width = $group->get('lgms_header_width')->getValue()[0]['value'];
+            switch ($width) {
+                case 'full-width':
+                    $variables['microsites']['header']['width']['full_width'] = TRUE;
+                    break;
 
-        case 'full-width-content-contained':
-          $variables['microsites']['header']['width']['full_width_content_contained'] = TRUE;
-          break;
+                case 'full-width-content-contained':
+                    $variables['microsites']['header']['width']['full_width_content_contained'] = TRUE;
+                    break;
 
-        case 'content-centered':
-          $variables['microsites']['header']['width']['content_centered'] = TRUE;
-          break;
+                case 'content-centered':
+                    $variables['microsites']['header']['width']['content_centered'] = TRUE;
+                    break;
 
-        default:
-          $variables['microsites']['header']['width']['full_width_content_contained'] = TRUE;
-          break;
-      }
+                default:
+                    $variables['microsites']['header']['width']['full_width_content_contained'] = TRUE;
+                    break;
+            }
+        }
+
+        $header_fields = [
+            'lgms_site_name',
+            'lgms_site_slogan',
+            'lgms_main_logo',
+        ];
+        foreach ($header_fields as $header_field) {
+            if (!empty($group->get($header_field)->getValue())) {
+                $variables['microsites']['header']['items'][$header_field] = $group->get($header_field)->view('microsite');
+            }
+        }
+
+        // Footer Items.
+        if (!empty($group->get('lgms_footer_width')->getValue())) {
+            $width = $group->get('lgms_footer_width')->getValue()[0]['value'];
+            switch ($width) {
+                case 'full-width':
+                    $variables['microsites']['footer']['width']['full_width'] = TRUE;
+                    break;
+
+                case 'full-width-content-contained':
+                    $variables['microsites']['footer']['width']['full_width_content_contained'] = TRUE;
+                    break;
+
+                case 'content-centered':
+                    $variables['microsites']['footer']['width']['content_centered'] = TRUE;
+                    break;
+
+                default:
+                    $variables['microsites']['footer']['width']['full_width_content_contained'] = TRUE;
+                    break;
+            }
+        }
+
+        $footer_fields = [
+            'lgms_footer_banner',
+            'lgms_footer_text_block_1',
+            'lgms_footer_text_block_2',
+            'lgms_footer_text_block_3',
+            'lgms_footer_text_block_4',
+            'lgms_footer_logos',
+            'lgms_footer_copyright_notice',
+        ];
+        foreach ($footer_fields as $footer_field) {
+            if (!empty($group->get($footer_field)->getValue())) {
+                $variables['microsites']['footer']['items'][$footer_field] = $group->get($footer_field)->view('microsite');
+            }
+        }
+        if (!empty($group->get('lgms_powered_by')->getValue()) && $group->get('lgms_powered_by')->getValue()[0]['value'] === '1') {
+            $variables['microsites']['footer']['items']['lgms_powered_by'] = t('<span>Powered by <a href="https://localgovdrupal.org">LocalGov Drupal</a></span>');
+        }
+
+        // Pre-header.
+        if (!empty($group->get('lgms_pre_header_width')->getValue())) {
+            $width = $group->get('lgms_pre_header_width')->getValue()[0]['value'];
+            switch ($width) {
+                case 'full-width':
+                    $variables['microsites']['pre_header']['width']['full_width'] = TRUE;
+                    break;
+
+                case 'full-width-content-contained':
+                    $variables['microsites']['pre_header']['width']['full_width_content_contained'] = TRUE;
+                    break;
+
+                case 'content-centered':
+                    $variables['microsites']['pre_header']['width']['content_centered'] = TRUE;
+                    break;
+
+                default:
+                    $variables['microsites']['pre_header']['width']['full_width_content_contained'] = TRUE;
+                    break;
+            }
+        }
+
+        $pre_header_fields = [
+            'lgms_display_sitewide_search',
+        ];
+        foreach ($pre_header_fields as $pre_header_field) {
+            if ($group->hasField($pre_header_field) && !empty($group->get($pre_header_field)->getValue())) {
+                $variables['microsites']['pre_header']['items'][$pre_header_field] = $group->get($pre_header_field)->view('microsite');
+            }
+        }
     }
-
-    $header_fields = [
-      'lgms_site_name',
-      'lgms_site_slogan',
-      'lgms_main_logo',
-    ];
-    foreach ($header_fields as $header_field) {
-      if (!empty($group->get($header_field)->getValue())) {
-        $variables['microsites']['header']['items'][$header_field] = $group->get($header_field)->view('microsite');
-      }
-    }
-
-    // Footer Items.
-    if (!empty($group->get('lgms_footer_width')->getValue())) {
-      $width = $group->get('lgms_footer_width')->getValue()[0]['value'];
-      switch ($width) {
-        case 'full-width':
-          $variables['microsites']['footer']['width']['full_width'] = TRUE;
-          break;
-
-        case 'full-width-content-contained':
-          $variables['microsites']['footer']['width']['full_width_content_contained'] = TRUE;
-          break;
-
-        case 'content-centered':
-          $variables['microsites']['footer']['width']['content_centered'] = TRUE;
-          break;
-
-        default:
-          $variables['microsites']['footer']['width']['full_width_content_contained'] = TRUE;
-          break;
-      }
-    }
-
-    $footer_fields = [
-      'lgms_footer_banner',
-      'lgms_footer_text_block_1',
-      'lgms_footer_text_block_2',
-      'lgms_footer_text_block_3',
-      'lgms_footer_text_block_4',
-      'lgms_footer_logos',
-      'lgms_footer_copyright_notice',
-    ];
-    foreach ($footer_fields as $footer_field) {
-      if (!empty($group->get($footer_field)->getValue())) {
-        $variables['microsites']['footer']['items'][$footer_field] = $group->get($footer_field)->view('microsite');
-      }
-    }
-    if (!empty($group->get('lgms_powered_by')->getValue()) && $group->get('lgms_powered_by')->getValue()[0]['value'] === '1') {
-      $variables['microsites']['footer']['items']['lgms_powered_by'] = t('<span>Powered by <a href="https://localgovdrupal.org">LocalGov Drupal</a></span>');
-    }
-
-    // Pre-header.
-    if (!empty($group->get('lgms_pre_header_width')->getValue())) {
-      $width = $group->get('lgms_pre_header_width')->getValue()[0]['value'];
-      switch ($width) {
-        case 'full-width':
-          $variables['microsites']['pre_header']['width']['full_width'] = TRUE;
-          break;
-
-        case 'full-width-content-contained':
-          $variables['microsites']['pre_header']['width']['full_width_content_contained'] = TRUE;
-          break;
-
-        case 'content-centered':
-          $variables['microsites']['pre_header']['width']['content_centered'] = TRUE;
-          break;
-
-        default:
-          $variables['microsites']['pre_header']['width']['full_width_content_contained'] = TRUE;
-          break;
-      }
-    }
-
-    $pre_header_fields = [
-      'lgms_display_sitewide_search',
-    ];
-    foreach ($pre_header_fields as $pre_header_field) {
-      if ($group->hasField($pre_header_field) && !empty($group->get($pre_header_field)->getValue())) {
-        $variables['microsites']['pre_header']['items'][$pre_header_field] = $group->get($pre_header_field)->view('microsite');
-      }
-    }
-  }
 }
 
 /**
  * Implements hook_theme_suggestions_page_alter().
  */
 function localgov_microsites_base_theme_suggestions_page_alter(array &$suggestions, array $variables) {
-  $routeMatch = \Drupal::routeMatch();
-  $node_preview = $routeMatch->getParameter('node_preview');
-  if ($node_preview instanceof NodeInterface) {
-    $suggestions[] = 'page__node__preview__' . $node_preview->bundle();
-    if ($view_mode_id = $routeMatch->getParameter('view_mode_id')) {
-      $suggestions[] = 'page__node__preview__' . $node_preview->bundle() . '__' . $view_mode_id;
+    $routeMatch = \Drupal::routeMatch();
+    $node_preview = $routeMatch->getParameter('node_preview');
+    if ($node_preview instanceof NodeInterface) {
+        $suggestions[] = 'page__node__preview__' . $node_preview->bundle();
+        if ($view_mode_id = $routeMatch->getParameter('view_mode_id')) {
+            $suggestions[] = 'page__node__preview__' . $node_preview->bundle() . '__' . $view_mode_id;
+        }
     }
-  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for fieldset.
+ *
+ * Appends " (optional)" to the fieldset legend for radios, checkboxes, and webform address fields
+ * instead of on individual control labels.
+ */
+function localgov_microsites_base_preprocess_fieldset(&$variables) {
+    $element = $variables['element'];
+
+    // Check if this fieldset contains supported element types.
+    $is_supported_fieldset_type = FALSE;
+    if (isset($element['#type']) && in_array($element['#type'], ['radios', 'checkboxes', 'webform_uk_address', 'webform_address'])) {
+        $is_supported_fieldset_type = TRUE;
+    }
+
+    // Check if the field is optional (not required).
+    $is_required = !empty($element['#required']);
+    $is_optional = !$is_required;
+
+    // Check if the fieldset has a legend title.
+    $has_legend = !empty($variables['legend']['title']);
+
+    // Append " (optional)" to the legend if this is an optional fieldset with a legend.
+    if ($is_supported_fieldset_type && $is_optional && $has_legend) {
+        $title = $variables['legend']['title'];
+        $optional_markup = ' <span class="form-optional">' . t(' (optional)') . '</span>';
+
+        if (is_array($title) && isset($title['#markup'])) {
+            $variables['legend']['title']['#markup'] .= $optional_markup;
+        }
+        elseif (is_string($title)) {
+            $variables['legend']['title'] = $title . $optional_markup;
+        }
+        elseif (is_object($title) && method_exists($title, '__toString')) {
+            $variables['legend']['title'] = [
+                '#markup' => $title->__toString() . $optional_markup,
+            ];
+        }
+        else {
+            $variables['legend']['title'] = [
+                '#markup' => (string) $title . $optional_markup,
+            ];
+        }
+        // Set a flag so form elements know not to show optional on individual items.
+        $variables['legend']['optional_appended'] = TRUE;
+    }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for form_element.
+ *
+ * Appends "(optional)" to standalone (not being a part of the fieldset) form element labels when not required.
+ * Supported types: checkbox, radio, textfield, textarea, email, tel, number, url, date, datetime, select.
+ * Does not append if the element is inside a fieldset that has a legend.
+ */
+function localgov_microsites_base_preprocess_form_element(&$variables) {
+    $element = $variables['element'];
+
+    // Check if this is a checkbox, radio, textfield, textarea, email, tel, number, url, date, datetime, or select.
+    if (!isset($element['#type']) || !in_array($element['#type'], ['checkbox', 'radio', 'textfield', 'textarea', 'email', 'tel', 'number', 'url', 'date', 'datetime', 'select'])) {
+        return;
+    }
+
+    // Check if the field is optional (not required).
+    $is_required = !empty($element['#required']);
+    $is_optional = !$is_required;
+
+    if (!$is_optional) {
+        return;
+    }
+
+    // Check if there's a label title to append to.
+    if (!isset($variables['label']['#title'])) {
+        return;
+    }
+
+    // For radios and checkboxes, check if they are part of a group (radios/checkboxes fieldset).
+    $is_part_of_fieldset_group = FALSE;
+    if (in_array($element['#type'], ['radio', 'checkbox'])) {
+        // Check if nested more than 2 levels deep (indicating it's inside a radios/checkboxes group).
+        if (!empty($element['#array_parents']) && count($element['#array_parents']) > 2) {
+            $is_part_of_fieldset_group = TRUE;
+        }
+        // Also check if there's a #group indicator.
+        if (!empty($element['#group'])) {
+            $is_part_of_fieldset_group = TRUE;
+        }
+    }
+
+    // Skip if this element is part of a fieldset group (legend already has optional marker).
+    if ($is_part_of_fieldset_group) {
+        return;
+    }
+
+    // Append " (optional)" to the label.
+    $title = $variables['label']['#title'];
+    $optional_markup = ' <span class="form-optional">' . t(' (optional)') . '</span>';
+
+    if (is_array($title) && isset($title['#markup'])) {
+        $variables['label']['#title']['#markup'] .= $optional_markup;
+    }
+    elseif (is_string($title)) {
+        $variables['label']['#title'] = $title . $optional_markup;
+    }
+    elseif (is_object($title) && method_exists($title, '__toString')) {
+        $variables['label']['#title'] = [
+            '#markup' => $title->__toString() . $optional_markup,
+        ];
+    }
+    else {
+        $variables['label']['#title'] = [
+            '#markup' => (string) $title . $optional_markup,
+        ];
+    }
 }


### PR DESCRIPTION
### Summary
Fixes #337 - Webform item labelling not working for radio/checkbox groups.

This PR replaces the CSS-based approach for displaying "(optional)" labels with PHP preprocess functions, which provide more reliable and consistent behaviour across all form element types.
### Problem
The existing CSS-based solution using `--form-item-optional-pseudocontent` had several issues:

1. **Radio/checkbox groups**: The "(optional)" text was incorrectly displayed on individual radio/checkbox control labels when selected, rather than on the fieldset legend.
2. **Required parent elements**: When a radio or checkbox was part of a required fieldset (using Webform's "Radios" or "Checkboxes" _parent_ elements), the individual control labels still incorrectly displayed "(optional)" when selected.
3. **Translation**: The CSS-based approach using pseudo-content cannot be translated for multilingual sites (Irish, Welsh, etc.).

### Solution
This PR implements two PHP preprocess functions that handle the "(optional)" label logic:

1. `localgov_microsites_base_preprocess_fieldset()`

Appends "(optional)" to the fieldset legend for supported element types: `radios`, `checkboxes`, `webform_uk_address`, `webform_address`. Only applies when the fieldset (_parent_ element) is not required and has a legend title.

2. `localgov_microsites_base_preprocess_form_element()`

Appends "(optional)" to standalone (not being a part of a fieldset/_parent_ element) form element labels. Supported types: `checkbox`, `radio`, `textfield`, `textarea`, `email`, `tel`, `number`, `url`, `date`, `datetime`, `select`. Detects if a radio/checkbox is part of a fieldset/_parent_ element (by checking `#array_parents` depth) and skips individual labels in that case, as the legend already displays the "(optional)" text.

### Changes

1. Added two preprocess functions to `localgov_microsites_base.theme` file.
2. Removed `--form-item-required-pseudocontent` and `--form-item-optional-pseudocontent` CSS variables from `css/base/variables.css` file.
3. Removed references to these CSS variables from `css/components/forms.css` file.