### PR TITLE
Added aria-expanded to menu toggle

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -16,12 +16,14 @@
 
         function handleOpenOffCanvas() {
           offCanvas.setAttribute("data-expanded", "true");
+          offCanvasToggle.setAttribute("aria-expanded", "true");
           focusable[0].focus();
         }
 
         function handleCloseOffCanvas() {
           offCanvasToggle.focus();
           offCanvas.setAttribute("data-expanded", "false");
+          offCanvasToggle.setAttribute("aria-expanded", "false");
         }
 
         function trapFocusInOffCanvasArea(element) {

--- a/templates/layout/includes/microsites-header.html.twig
+++ b/templates/layout/includes/microsites-header.html.twig
@@ -95,7 +95,9 @@
         </div>
       {% endif %}
       <div class="microsite-header__off-canvas">
-        <button class="microsite-header__off-canvas-toggle" aria-controls="off-canvas">{{ 'Menu'|t }}</button>
+        <button class="microsite-header__off-canvas-toggle" aria-controls="off-canvas" aria-expanded="false">
+          {{ 'Menu'|t }}
+        </button>
       </div>
     </div>
     {# End Microsite Header Main #}


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds aria-expanded attribute to the off-canvas menu toggle button. The attribute is set to false in the template (closed by default) and toggled to true/false via JS as the menu opens and closes. Screen readers can now announce the menu state to users.

## How to test

- Navigate to a microsite with the off-canvas menu
- Tab to the Menu button — screen reader should announce "Menu, collapsed button"
- Activate the button — should announce "Menu, expanded button"
- Close the menu — should announce "Menu, collapsed button"
- Alternatively: inspect the DOM and confirm aria-expanded flips between true/false on toggle


## How can we measure success?

Manual screen reader test passes as above.

## Have we considered potential risks?

Low risk — additive change only. No visual change, no logic change. The JS already managed open/close state; this just reflects it in the ARIA attribute
## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)